### PR TITLE
feat:docker-VmApiを追加

### DIFF
--- a/src/component/alert/alert.tsx
+++ b/src/component/alert/alert.tsx
@@ -1,0 +1,38 @@
+import * as React from "react";
+import Box from "@mui/material/Box";
+import Alert, { AlertColor } from "@mui/material/Alert";
+import IconButton from "@mui/material/IconButton";
+import Collapse from "@mui/material/Collapse";
+import CloseIcon from "@mui/icons-material/Close";
+
+export function TransitionAlerts(props: {
+  children: React.ReactNode;
+  severity?: AlertColor;
+}) {
+  const [open, setOpen] = React.useState(true);
+
+  return (
+    <Box sx={{ width: "100%" }}>
+      <Collapse in={open}>
+        <Alert
+          severity={props.severity}
+          action={
+            <IconButton
+              aria-label="close"
+              color="inherit"
+              size="small"
+              onClick={() => {
+                setOpen(false);
+              }}
+            >
+              <CloseIcon fontSize="inherit" />
+            </IconButton>
+          }
+          sx={{ mb: 2 }}
+        >
+          {props.children}
+        </Alert>
+      </Collapse>
+    </Box>
+  );
+}

--- a/src/component/editor/setting-window/item/judge-mode.tsx
+++ b/src/component/editor/setting-window/item/judge-mode.tsx
@@ -10,7 +10,7 @@ import Radio from "@mui/material/Radio";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import { ipcRendererManager } from "../../../../ipc";
 
-const options = ["online", "local"];
+const options = ["online", "local", "docker"];
 
 export interface ConfirmationDialogRawProps {
   id: string;

--- a/src/component/editor/tool/setting/languagedialog.tsx
+++ b/src/component/editor/tool/setting/languagedialog.tsx
@@ -53,7 +53,7 @@ export function SelectLanguageDialog(props: SelectLanguageDialogProps) {
             {langState.langOptions.map((lang) => (
               <FormControlLabel
                 key={lang.langid}
-                value={lang}
+                value={lang.langid}
                 control={<Radio />}
                 label={lang.langName}
               />

--- a/src/component/menu/main.tsx
+++ b/src/component/menu/main.tsx
@@ -29,6 +29,8 @@ import { IconButton } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import { SnackMessage } from "../snackbar/snackbar";
 import { submitStatus } from "../../../src_main/data/scraping/submit-data";
+import PlayCircleFilledWhiteIcon from "@mui/icons-material/PlayCircleFilledWhite";
+import { VmSetup } from "../vm-setup/home";
 
 const drawerWidth = 240;
 // let nowItem = 0;
@@ -208,13 +210,19 @@ export const WindowRoot = () => {
       icon: <LiveTv />,
       component: <Window />,
     },
-
     {
       id: 4,
       viewName: "case",
       text: "テストケース",
       icon: <AssignmentTurnedInIcon />,
       component: <TestCaseBoard />,
+    },
+    {
+      id: 5,
+      viewName: "judgevm",
+      text: "仮想マシン",
+      icon: <PlayCircleFilledWhiteIcon />,
+      component: <VmSetup />,
     },
   ];
 

--- a/src/component/vm-setup/docker-judge/docker-start.tsx
+++ b/src/component/vm-setup/docker-judge/docker-start.tsx
@@ -1,0 +1,46 @@
+import { Box, Button } from "@mui/material";
+import { VmStatusTable } from "./docker-status";
+import RuleIcon from "@mui/icons-material/Rule";
+import { useContext } from "react";
+import { DockerStatusContext } from "./docker-status-hooks";
+import PlayCircleOutlineIcon from "@mui/icons-material/PlayCircleOutline";
+import ChangeCircleIcon from "@mui/icons-material/ChangeCircle";
+export const DockerContainerStart = () => {
+  const dockerStatusHooks = useContext(DockerStatusContext);
+  return (
+    <>
+      <Box my={3}>
+        <Button
+          onClick={dockerStatusHooks.updateStatus}
+          variant="outlined"
+          startIcon={<RuleIcon />}
+        >
+          ジャッジコンテナの起動状況を確認する
+        </Button>
+      </Box>
+      <VmStatusTable />
+      {dockerStatusHooks.dockerVmStatus === "noContainer" && (
+        <Box mt={3}>
+          <Button
+            onClick={dockerStatusHooks.startContainer}
+            variant="outlined"
+            startIcon={<PlayCircleOutlineIcon />}
+          >
+            ジャッジコンテナを起動する
+          </Button>
+        </Box>
+      )}
+      {dockerStatusHooks.dockerVmStatus === "down" && (
+        <Box mt={3}>
+          <Button
+            onClick={dockerStatusHooks.restartContainer}
+            variant="outlined"
+            startIcon={<ChangeCircleIcon />}
+          >
+            ジャッジコンテナを再起動する
+          </Button>
+        </Box>
+      )}
+    </>
+  );
+};

--- a/src/component/vm-setup/docker-judge/docker-status-hooks.ts
+++ b/src/component/vm-setup/docker-judge/docker-status-hooks.ts
@@ -1,0 +1,140 @@
+import { createContext, useState } from "react";
+import {
+  checkDockerInstalledReturn,
+  dockerPSReturn,
+  getDockerHisuiJudgeContainerStatusReturn,
+} from "../../../../src_main/vm-system/vm-docker";
+import { ipcRendererManager } from "../../../ipc";
+
+export const useDockerSetup = () => {
+  // Stepperに関するState
+  const [activeStep, setActiveStep] = useState(0);
+  const [nextOk, setNextOk] = useState<boolean>(false);
+  // Dockerのインストールチェックに関するState
+  const [dockerVersionLog, setDockerVersionLog] = useState<string>("");
+  const [dockerVersionStatus, setDockerVersionStatus] = useState<
+    boolean | "ready"
+  >("ready");
+  // コンテナ起動に関するState
+  const [dockerVmStatusObject, setDockerVmStatusObject] =
+    useState<dockerPSReturn | null>(null);
+  const [dockerVmStatus, setDockerVmStatus] = useState<
+    "up" | "noContainer" | "error" | "down" | null
+  >(null);
+  const [dockerRunStatus, setDockerRunStatus] = useState<
+    "success" | "error" | "waiting" | null
+  >(null);
+
+  /**
+   * Dockerのインストール状況を確認する
+   * バーションを取得
+   */
+  const checkDocker = async () => {
+    const getStatus: checkDockerInstalledReturn =
+      await ipcRendererManager.invoke("GET_DOCKER_VERSION");
+    setDockerVersionLog(getStatus.stdout);
+    if (getStatus.status !== "error") {
+      setDockerVersionStatus(true);
+      setNextOk(true);
+    } else {
+      setDockerVersionStatus(false);
+    }
+  };
+  /**
+   * コンテナ（adenohitu/hisui-judge-docker）の起動状況を取得
+   */
+  const updateStatus = async () => {
+    const getDockerStatus: getDockerHisuiJudgeContainerStatusReturn =
+      await ipcRendererManager.invoke("GET_DOCKER_HISUIJUDGECONTAINER_STATUS");
+    if (getDockerStatus.result) {
+      setDockerVmStatusObject(getDockerStatus.result);
+    } else {
+      setDockerVmStatusObject(null);
+    }
+    if (getDockerStatus.status === "up") {
+      setNextOk(true);
+    } else {
+      setNextOk(false);
+    }
+    setDockerVmStatus(getDockerStatus.status);
+  };
+
+  const startContainer = async () => {
+    if (dockerVmStatus === "noContainer") {
+      setDockerRunStatus("waiting");
+      const waitRun: "success" | "error" = await ipcRendererManager.invoke(
+        "RUN_DOCKER_START_HISUIJUDGECONTAINER"
+      );
+      if (waitRun === "success") {
+        setNextOk(true);
+        setDockerRunStatus("success");
+        updateStatus();
+      } else {
+        setDockerRunStatus("error");
+      }
+    }
+  };
+  const stopContainer = async () => {
+    const waitRun: "success" | "error" = await ipcRendererManager.invoke(
+      "RUN_DOCKER_STOP_HISUIJUDGECONTAINER"
+    );
+    if (waitRun === "success") {
+      setDockerRunStatus(null);
+      updateStatus();
+    } else {
+      setDockerRunStatus("error");
+    }
+  };
+  const reStartContainer = async () => {
+    const waitRun: "error" | "success" | "stopError" =
+      await ipcRendererManager.invoke("RUN_DOCKER_RESTART_HISUIJUDGECONTAINER");
+    if (waitRun === "success") {
+      setNextOk(true);
+      setDockerRunStatus("success");
+      updateStatus();
+    } else {
+      setDockerRunStatus("error");
+    }
+  };
+
+  const handleNext = () => {
+    setNextOk(false);
+    setActiveStep((prevActiveStep) => prevActiveStep + 1);
+  };
+  const resetStep = () => {
+    setActiveStep(0);
+    setNextOk(false);
+    setDockerVersionLog("");
+    setDockerVersionStatus("ready");
+    setDockerVmStatus(null);
+    setDockerRunStatus(null);
+  };
+
+  return {
+    activeStep,
+    setActiveStep,
+    nextOk,
+    setNextOk,
+    dockerVersionLog,
+    setDockerVersionLog,
+    dockerVersionStatus,
+    setDockerVersionStatus,
+    dockerVmStatusObject,
+    setDockerVmStatusObject,
+    dockerVmStatus,
+    setDockerVmStatus,
+    dockerRunStatus,
+    setDockerRunStatus,
+    startContainer,
+    stopContainer,
+    restartContainer: reStartContainer,
+    updateStatus,
+    checkDocker,
+    handleNext,
+    resetStep,
+  };
+};
+type statusContextTypes = ReturnType<typeof useDockerSetup>;
+export const DockerStatusContext = createContext<statusContextTypes>(
+  {} as statusContextTypes
+);

--- a/src/component/vm-setup/docker-judge/docker-status.tsx
+++ b/src/component/vm-setup/docker-judge/docker-status.tsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import Paper from "@mui/material/Paper";
+import { DockerStatusContext } from "./docker-status-hooks";
+
+export function VmStatusTable() {
+  const dockerStatusHooks = React.useContext(DockerStatusContext);
+  return (
+    <TableContainer component={Paper}>
+      <Table sx={{ minWidth: 650 }} aria-label="simple table">
+        <TableHead>
+          <TableRow>
+            <TableCell>ID</TableCell>
+            <TableCell>Image</TableCell>
+            <TableCell>Names</TableCell>
+            <TableCell>Status</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {dockerStatusHooks.dockerVmStatusObject && (
+            <TableRow
+              sx={{ "&:last-child td, &:last-child th": { border: 0 } }}
+            >
+              <TableCell component="th" scope="row">
+                {dockerStatusHooks.dockerVmStatusObject.ID}
+              </TableCell>
+              <TableCell>
+                {dockerStatusHooks.dockerVmStatusObject.Image}
+              </TableCell>
+              <TableCell>
+                {dockerStatusHooks.dockerVmStatusObject.Names}
+              </TableCell>
+              <TableCell>
+                {dockerStatusHooks.dockerVmStatusObject.Status}
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}

--- a/src/component/vm-setup/docker-judge/docker-version.tsx
+++ b/src/component/vm-setup/docker-judge/docker-version.tsx
@@ -1,0 +1,35 @@
+import { Box, Button, Chip, Stack } from "@mui/material";
+import { useContext } from "react";
+import RuleIcon from "@mui/icons-material/Rule";
+import { DockerStatusContext } from "./docker-status-hooks";
+export function GetDockerVersion() {
+  const dockerStatusHooks = useContext(DockerStatusContext);
+  return (
+    <Box my={2}>
+      <Button
+        onClick={dockerStatusHooks.checkDocker}
+        variant="outlined"
+        startIcon={<RuleIcon />}
+      >
+        Dockerのインストール状況をチェックする
+      </Button>
+
+      <Stack
+        direction="row"
+        justifyContent="flex-start"
+        alignItems="center"
+        mt={2}
+        spacing={2}
+      >
+        {(dockerStatusHooks.dockerVersionStatus !== "ready" &&
+          dockerStatusHooks.dockerVersionStatus === true && (
+            <Chip label="OK" color="success" />
+          )) ||
+          (dockerStatusHooks.dockerVersionStatus === false && (
+            <Chip label="Failure" color="error" />
+          ))}
+        <h2>{dockerStatusHooks.dockerVersionLog}</h2>
+      </Stack>
+    </Box>
+  );
+}

--- a/src/component/vm-setup/docker-judge/docker.tsx
+++ b/src/component/vm-setup/docker-judge/docker.tsx
@@ -1,0 +1,75 @@
+import Box from "@mui/material/Box";
+import Stepper from "@mui/material/Stepper";
+import Step from "@mui/material/Step";
+import StepLabel from "@mui/material/StepLabel";
+import Button from "@mui/material/Button";
+import { Fragment, useContext } from "react";
+import { GetDockerVersion } from "./docker-version";
+import { DockerStatusContext } from "./docker-status-hooks";
+import { DockerContainerStart } from "./docker-start";
+const steps = [
+  {
+    title: "Dockerのインストール",
+    component: (
+      <>
+        <GetDockerVersion />
+      </>
+    ),
+  },
+  {
+    title: "Dockerコンテナの起動",
+    component: (
+      <>
+        <DockerContainerStart />
+      </>
+    ),
+  },
+  {
+    title: "準備完了",
+    component: (
+      <>
+        <h1>全ての準備が整いました。</h1>
+      </>
+    ),
+  },
+];
+
+export function VmSetupStepperDocker() {
+  const dockerStatusHooks = useContext(DockerStatusContext);
+
+  return (
+    <Box sx={{ width: "100%" }}>
+      <Stepper activeStep={dockerStatusHooks?.activeStep}>
+        {steps.map((step, index) => {
+          const stepProps: { completed?: boolean } = {};
+          const labelProps: {
+            optional?: React.ReactNode;
+          } = {};
+          return (
+            <Step key={index} {...stepProps}>
+              <StepLabel {...labelProps}>{step.title}</StepLabel>
+            </Step>
+          );
+        })}
+      </Stepper>
+      <Fragment>
+        {steps[dockerStatusHooks.activeStep].component}
+        <Box sx={{ display: "flex", flexDirection: "row", pt: 2 }}>
+          <Box sx={{ flex: "1 1 auto" }} />
+          <Button
+            disabled={dockerStatusHooks.nextOk === false}
+            onClick={dockerStatusHooks.handleNext}
+          >
+            次へ
+          </Button>
+          <Button
+            disabled={dockerStatusHooks.activeStep !== steps.length - 1}
+            onClick={dockerStatusHooks.resetStep}
+          >
+            最初に戻る
+          </Button>
+        </Box>
+      </Fragment>
+    </Box>
+  );
+}

--- a/src/component/vm-setup/home.tsx
+++ b/src/component/vm-setup/home.tsx
@@ -1,0 +1,81 @@
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import {
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  Container,
+  Stack,
+} from "@mui/material";
+import { VmSetupStepperDocker } from "./docker-judge/docker";
+import { TransitionAlerts } from "../alert/alert";
+import {
+  DockerStatusContext,
+  useDockerSetup,
+} from "./docker-judge/docker-status-hooks";
+import { VmStatusTable } from "./docker-judge/docker-status";
+import RefreshIcon from "@mui/icons-material/Refresh";
+import StopCircleIcon from "@mui/icons-material/StopCircle";
+import ChangeCircleIcon from "@mui/icons-material/ChangeCircle";
+
+export function VmSetup() {
+  const dockerStatusHooks = useDockerSetup();
+  return (
+    <Box sx={{ height: "100%", width: "100%", backgroundColor: "#ffffff" }}>
+      <Container sx={{ marginTop: "10px" }}>
+        <Typography variant="h4">
+          ローカルジャッジ仮想マシン（試験機能）
+        </Typography>
+        <TransitionAlerts severity="warning">
+          この機能は試験的な機能です。
+          <br />
+          既存のDockerの環境に影響を与える可能性があります。注意してください
+        </TransitionAlerts>
+        <DockerStatusContext.Provider value={dockerStatusHooks}>
+          <Box mb={5}>
+            <Card variant="outlined">
+              <CardContent>
+                <h1>ジャッジシステム状況</h1>
+                <Box my={1}>
+                  <Button
+                    onClick={dockerStatusHooks.updateStatus}
+                    variant="outlined"
+                    startIcon={<RefreshIcon />}
+                  >
+                    更新する
+                  </Button>
+                </Box>
+                <VmStatusTable />
+              </CardContent>
+              <CardActions>
+                {dockerStatusHooks.dockerVmStatusObject !== null && (
+                  <Box mt={3}>
+                    <Stack spacing={2} direction="row">
+                      <Button
+                        onClick={dockerStatusHooks.stopContainer}
+                        variant="outlined"
+                        startIcon={<StopCircleIcon />}
+                      >
+                        起動中のJudgeContainerを停止・削除する
+                      </Button>
+                      <Button
+                        onClick={dockerStatusHooks.restartContainer}
+                        variant="outlined"
+                        startIcon={<ChangeCircleIcon />}
+                      >
+                        ジャッジコンテナを再起動する
+                      </Button>
+                    </Stack>
+                  </Box>
+                )}
+              </CardActions>
+            </Card>
+          </Box>
+
+          <VmSetupStepperDocker />
+        </DockerStatusContext.Provider>
+      </Container>
+    </Box>
+  );
+}

--- a/src_main/code-test/docker.ts
+++ b/src_main/code-test/docker.ts
@@ -1,0 +1,21 @@
+export const hisuiDockerJudgeCommand: {
+  [id: number]: {
+    preRunCommand: string | null;
+    compilerCommand: string | null;
+    runCommand: string;
+  };
+} = {
+  4003: {
+    preRunCommand: 'docker cp "{filepath}" hisui-judge-docker:/home/cpp/a.cpp',
+    compilerCommand:
+      "docker exec hisui-judge-docker g++ -std=gnu++17 -Wall -Wextra -O2 -DONLINE_JUDGE -o /home/cpp/a.out /home/cpp/a.cpp",
+    runCommand: "docker exec -i hisui-judge-docker /home/cpp/a.out",
+  },
+  4006: {
+    preRunCommand:
+      'docker cp "{filepath}" hisui-judge-docker:/home/python/main.py',
+    compilerCommand: null,
+    runCommand:
+      "docker exec -i hisui-judge-docker python3 /home/python/main.py",
+  },
+};

--- a/src_main/code-test/runner/command-runner/command-runner-docker.test.ts
+++ b/src_main/code-test/runner/command-runner/command-runner-docker.test.ts
@@ -1,0 +1,56 @@
+import { readFile } from "fs/promises";
+import path from "path";
+import { vmDockerApi } from "../../../vm-system/vm-docker";
+import { runTestWithCommand, runTestWithCommandArgs } from "./command-runner";
+jest.setTimeout(100000);
+// コンテナの起動
+beforeAll(async () => {
+  return await vmDockerApi.startDockerHisuiJudge();
+});
+
+// afterAll(async () => {
+//   return await vmDockerApi.stopDockerHisuiJudge();
+// });
+test("runTest with Command by Docker", async () => {
+  const filepath = path.join(
+    __dirname,
+    "../../../../archive/test-data/abc164_b/b.cpp"
+  );
+  const outfilepath = path.join(
+    __dirname,
+    "../../../../archive/test-data/abc164_b/b.out"
+  );
+  const inputFiledir = path.join(
+    __dirname,
+    "../../../../archive/test-data/abc164_b/sample/1.in"
+  );
+  const input = await readFile(inputFiledir, "utf-8");
+  const outputFiledir = path.join(
+    __dirname,
+    "../../../../archive/test-data/abc164_b/sample/1.out"
+  );
+  const output = await readFile(outputFiledir, "utf-8");
+
+  const testArgs: runTestWithCommandArgs = {
+    preRunCommand: "docker cp {filepath} hisui-judge-docker:/home/cpp/a.cpp",
+    compilerCommand:
+      "docker exec hisui-judge-docker g++ -std=gnu++17 -Wall -Wextra -O2 -DONLINE_JUDGE -o /home/cpp/a.out /home/cpp/a.cpp",
+    runCommand: "docker exec -i hisui-judge-docker /home/cpp/a.out",
+    filepath: filepath,
+    outfilepath: outfilepath,
+    codeTestIn: {
+      languageId: "4003",
+      code: "",
+      codeTestProps: {
+        input: input,
+        answer: null,
+        caseName: "1",
+        testGroupID: "view-button:/contests/abc164/tasks/abc164_b",
+        TaskScreenName: "abc164_b",
+      },
+    },
+  };
+  const data = await runTestWithCommand(testArgs, 1, "docker");
+
+  expect(data.Stdout).toEqual(output);
+});

--- a/src_main/code-test/runner/command-runner/command-runner.test.ts
+++ b/src_main/code-test/runner/command-runner/command-runner.test.ts
@@ -1,0 +1,49 @@
+import { readFile } from "fs/promises";
+import path from "path";
+import { runTestWithCommand, runTestWithCommandArgs } from "./command-runner";
+jest.setTimeout(100000);
+
+test("runTest with Command", async () => {
+  const filepath = path.join(
+    __dirname,
+    "../../../../archive/test-data/abc164_b/b.cpp"
+  );
+  const outfilepath = path.join(
+    __dirname,
+    "../../../../archive/test-data/abc164_b/b.out"
+  );
+  const inputFiledir = path.join(
+    __dirname,
+    "../../../../archive/test-data/abc164_b/sample/1.in"
+  );
+  const input = await readFile(inputFiledir, "utf-8");
+  const outputFiledir = path.join(
+    __dirname,
+    "../../../../archive/test-data/abc164_b/sample/1.out"
+  );
+  const output = await readFile(outputFiledir, "utf-8");
+
+  const testArgs: runTestWithCommandArgs = {
+    preRunCommand: null,
+    compilerCommand:
+      "g++ -std=gnu++17 -Wall -Wextra -O2 -DONLINE_JUDGE -o {outfilepath} {filepath}",
+    runCommand: "{outfilepath}",
+    filepath: filepath,
+    outfilepath: outfilepath,
+    codeTestIn: {
+      languageId: "4003",
+      code: "",
+      codeTestProps: {
+        input: input,
+        answer: null,
+        caseName: "1",
+        testGroupID: "view-button:/contests/abc164/tasks/abc164_b",
+        TaskScreenName: "abc164_b",
+      },
+    },
+  };
+  const data = await runTestWithCommand(testArgs, 1, "Docker");
+  console.log(data);
+
+  expect(data.Stdout).toEqual(output);
+});

--- a/src_main/code-test/runner/command-runner/command-runner.ts
+++ b/src_main/code-test/runner/command-runner/command-runner.ts
@@ -1,0 +1,280 @@
+// コマンドでローカルのコンパイラー等を使用して、コードテストを実行する
+// パイプを使用するため、shell:true
+// https://github.com/nodejs/node/issues/7367
+// https://github.com/nodejs/node-v0.x-archive/issues/25895
+import { exec, spawn } from "child_process";
+import { atcoderCodeTestResult, codeTestIn } from "../../codetest";
+import { logger } from "../../../tool/logger/logger";
+import { languages } from "../../../file/extension";
+// import { codeTestIn } from "../data/casetester/runtest_atcoder";
+// "cpp": "cd $dir && /usr/local/bin/g++ $fileName -D=__LOCAL -o $fileNameWithoutExt && $dir$fileNameWithoutExt"
+// g++ -std=gnu++17 -Wall -Wextra -O2 -DONLINE_JUDGE -I/opt/boost/gcc/include -L/opt/boost/gcc/lib -I/opt/ac-library -o {outfilepath} {filepath}
+export interface runTestWithCommandArgs {
+  preRunCommand: string | null;
+  compilerCommand: string | null;
+  skipCompile?: boolean;
+  runCommand: string;
+  filepath: string;
+  // コンパイルの出力先
+  outfilepath: string;
+  codeTestIn: codeTestIn;
+}
+export interface LocalCodeTestResult extends atcoderCodeTestResult {
+  LocalCodeRunArgs: runTestWithCommandArgs;
+}
+
+export async function runTestWithCommand(
+  args: runTestWithCommandArgs,
+  compileID: number,
+  toolName: string
+): Promise<LocalCodeTestResult> {
+  const createdDate = new Date().toISOString();
+
+  const preRun = await preRunCommand(args, compileID, createdDate);
+  if (preRun.status !== "preRunError") {
+    return new Promise<LocalCodeTestResult>((resolve) => {
+      if (!args.skipCompile && args.compilerCommand !== null) {
+        try {
+          // コンパイル
+          const replacedCommand = commandReplace(
+            args.compilerCommand,
+            args.outfilepath,
+            args.filepath
+          );
+          const compile = spawn(replacedCommand, { shell: true });
+          let conpileStdError = "";
+          compile.stdout.on("data", (data) => {
+            conpileStdError += data.toString();
+            logger.info(`STDOUT:${data.toString()}`, "commad Tester");
+          });
+          compile.stderr.on("data", (data) => {
+            conpileStdError += data.toString();
+            logger.info(`STDERR:${data.toString()}`, "commad Tester");
+          });
+          compile.on("close", async (code) => {
+            logger.info(`Conpile CODE: ${code}`, "commad Tester");
+            let ExitCode = -1;
+            if (code === 0) {
+              ExitCode = 0;
+            } else {
+              resolve({
+                LocalCodeRunArgs: args,
+                caseName: args.codeTestIn.codeTestProps.caseName,
+                testGroup: args.codeTestIn.codeTestProps.testGroupID,
+                ansStatus: "CE",
+                Result: {
+                  Id: compileID,
+                  SourceCode: "",
+                  Input: args.codeTestIn.codeTestProps.input,
+                  Output: "",
+                  Error: "",
+                  TimeConsumption: -1,
+                  MemoryConsumption: -1,
+                  ExitCode,
+                  Status: 3,
+                  Created: createdDate,
+                  LanguageId: Number(args.codeTestIn.languageId),
+                  LanguageName:
+                    Object.keys(languages).find((e) => {
+                      return (
+                        languages[e].submitLanguageId ===
+                        Number(args.codeTestIn.languageId)
+                      );
+                    }) + ` (${toolName})` || `CommandRunner (${toolName})`,
+                },
+                Stderr: conpileStdError,
+                Stdout: "",
+              });
+            }
+          });
+          compile.on("close", () => {
+            runTest(args, compileID, createdDate, toolName).then((result) => {
+              resolve(result);
+            });
+          });
+          // 実行
+        } catch (e: any) {
+          const errorMessage: Error = e;
+          resolve({
+            LocalCodeRunArgs: args,
+            caseName: args.codeTestIn.codeTestProps.caseName,
+            testGroup: args.codeTestIn.codeTestProps.testGroupID,
+            ansStatus: "CE",
+            Result: {
+              Id: compileID,
+              SourceCode: "",
+              Input: args.codeTestIn.codeTestProps.input,
+              Output: "",
+              Error: "",
+              TimeConsumption: -1,
+              MemoryConsumption: -1,
+              ExitCode: -1,
+              Status: 3,
+              Created: createdDate,
+              LanguageId: Number(args.codeTestIn.languageId),
+              LanguageName:
+                Object.keys(languages).find((e) => {
+                  return (
+                    languages[e].submitLanguageId === args.codeTestIn.languageId
+                  );
+                }) + ` (${toolName})` || `CommandRunner (${toolName})`,
+            },
+            Stderr:
+              "コンパイラーのパスが正しくしてされていない可能性があります。",
+            Stdout: "",
+          });
+          logger.error(errorMessage.message);
+        }
+      } else {
+        runTest(args, compileID, createdDate, toolName).then((result) => {
+          resolve(result);
+        });
+      }
+    });
+  } else {
+    // preRunに失敗
+    return {
+      LocalCodeRunArgs: args,
+      ansStatus: "CE",
+      Result: {
+        Id: compileID,
+        SourceCode: "",
+        Input: args.codeTestIn.codeTestProps.input,
+        Output: "",
+        Error: "",
+        TimeConsumption: -1,
+        MemoryConsumption: -1,
+        ExitCode: -1,
+        Status: 3,
+        Created: createdDate,
+        LanguageId: Number(args.codeTestIn.languageId),
+        LanguageName:
+          Object.keys(languages).find((e) => {
+            return (
+              languages[e].submitLanguageId ===
+              Number(args.codeTestIn.languageId)
+            );
+          }) + ` (${toolName})` || `CommandRunner (${toolName})`,
+      },
+      Stderr: "PreRunに失敗しました",
+      Stdout: "",
+    };
+  }
+}
+/**
+ * コンパイル前に実行する
+ */
+async function preRunCommand(
+  args: runTestWithCommandArgs,
+  compileID: number,
+  createdDate: string
+): Promise<{
+  status: "skip" | "success" | "preRunError";
+  stdout?: string;
+}> {
+  if (args.preRunCommand !== null) {
+    const replacedCommand = commandReplace(
+      args.preRunCommand,
+      args.outfilepath,
+      args.filepath
+    );
+    const run = await new Promise<{
+      status: "success" | "preRunError";
+      stdout?: string;
+    }>((resolve) => {
+      // パイプを使用するため、shell:true
+      exec(replacedCommand, (error, stdout, stderr) => {
+        if (error) {
+          console.log(error);
+          resolve({ status: "preRunError", stdout: stderr });
+        } else {
+          resolve({ status: "success", stdout: stdout });
+        }
+      });
+    });
+    return run;
+  } else {
+    return { status: "skip" };
+  }
+}
+function runTest(
+  args: runTestWithCommandArgs,
+  compileID: number,
+  createdDate: string,
+  toolName: String
+): Promise<LocalCodeTestResult> {
+  return new Promise((resolve) => {
+    // 出力保持用
+    let stdout = "";
+    let stdError = "";
+    const replacedCommand = commandReplace(
+      args.runCommand,
+      args.outfilepath,
+      args.filepath
+    );
+    const runner = spawn(replacedCommand, {
+      shell: true,
+      timeout: 10000,
+    });
+    runner.stdin.write(args.codeTestIn.codeTestProps.input);
+
+    runner.stdout.on("data", (rawData) => {
+      const data = rawData.toString("utf-8");
+      logger.info(`STDOUT: ${data}`, "commad Tester");
+      stdout = data;
+    });
+    runner.on("error", (err) => {
+      logger.info(`STDERR: ${err.message}`, "commad Tester");
+      stdError += err.message;
+    });
+    runner.on("close", (code) => {
+      logger.info(`Run CODE: ${code}`, "commad Tester");
+
+      let ExitCode = -1;
+      if (code === 0) {
+        ExitCode = 0;
+      } else if (code === null) {
+        ExitCode = -1;
+      } else {
+        ExitCode = code;
+      }
+      resolve({
+        LocalCodeRunArgs: args,
+        caseName: args.codeTestIn.codeTestProps.caseName,
+        testGroup: args.codeTestIn.codeTestProps.testGroupID,
+        Result: {
+          Id: compileID,
+          SourceCode: "",
+          Input: args.codeTestIn.codeTestProps.input,
+          Output: "",
+          Error: "",
+          TimeConsumption: -1,
+          MemoryConsumption: -1,
+          ExitCode,
+          Status: 0,
+          // ISO 8601
+          Created: createdDate,
+          LanguageId: Number(args.codeTestIn.languageId),
+          LanguageName:
+            Object.keys(languages).find((e) => {
+              return (
+                languages[e].submitLanguageId ===
+                Number(args.codeTestIn.languageId)
+              );
+            }) + ` (${toolName})` || `CommandRunner (${toolName})`,
+        },
+        Stderr: stdError,
+        Stdout: stdout,
+      });
+    });
+  });
+}
+function commandReplace(
+  command: string,
+  outfilepath: string,
+  filepath: string
+) {
+  return command
+    .replace("{outfilepath}", outfilepath)
+    .replace("{filepath}", filepath);
+}

--- a/src_main/code-test/runner/local-cpp/local-tester-cpp.test.ts
+++ b/src_main/code-test/runner/local-cpp/local-tester-cpp.test.ts
@@ -1,7 +1,7 @@
 import { readFile } from "fs/promises";
 import path from "path";
 import { LocalCodeRunArgs, runLocalTest } from "./local-tester-cpp";
-jest.setTimeout(20000);
+jest.setTimeout(50000);
 test("Local Judge Test: pathError", async () => {
   const filepath = path.join(
     __dirname,

--- a/src_main/editor/taskcont.ts
+++ b/src_main/editor/taskcont.ts
@@ -186,7 +186,7 @@ export class taskcont {
    */
   async languageChange(language: languagetype, load: boolean) {
     logger.info(
-      `Change editor language ${this.language} to ${this.language}`,
+      `Change editor language ${language} to ${this.language}`,
       `taskcont:${this.taskScreenName}`
     );
     await this.save();

--- a/src_main/ipc/events.ts
+++ b/src_main/ipc/events.ts
@@ -102,6 +102,12 @@ export const IpcEvents = {
   LSP_SEND: { mode: "send" },
   LSP_ON: { mode: "on" },
   LSP_READY: { mode: "send" },
+  // VmSettingIPC
+  GET_DOCKER_VERSION: { mode: "handle" },
+  GET_DOCKER_HISUIJUDGECONTAINER_STATUS: { mode: "handle" },
+  RUN_DOCKER_START_HISUIJUDGECONTAINER: { mode: "handle" },
+  RUN_DOCKER_STOP_HISUIJUDGECONTAINER: { mode: "handle" },
+  RUN_DOCKER_RESTART_HISUIJUDGECONTAINER: { mode: "handle" },
 };
 export type IpcEventsKey = keyof typeof IpcEvents;
 export const EventsArrey = Object.entries(IpcEvents);

--- a/src_main/ipc/ipc_main.ts
+++ b/src_main/ipc/ipc_main.ts
@@ -15,6 +15,7 @@ import { submissionsApi } from "../data/submissions";
 import { ipcMainManager } from "./ipc";
 import { setWindowSplit } from "../browser/tool/monitorsize";
 import { taskViewWindowApi } from "../browser/taskviewwindow";
+import { vmDockerApi } from "../vm-system/vm-docker";
 //ipc通信
 export const load_ipc = () => {
   //ブラウザでurlを開く
@@ -145,5 +146,25 @@ export const load_ipc = () => {
   });
   ipcMainManager.handle("GET_OS", async () => {
     return process.platform;
+  });
+  ipcMainManager.handle("GET_DOCKER_VERSION", async () => {
+    const data = await vmDockerApi.checkDockerInstalled();
+    return data;
+  });
+  ipcMainManager.handle("GET_DOCKER_HISUIJUDGECONTAINER_STATUS", async () => {
+    const data = await vmDockerApi.getDockerHisuiJudgeContainerStatus();
+    return data;
+  });
+  ipcMainManager.handle("RUN_DOCKER_START_HISUIJUDGECONTAINER", async () => {
+    const data = await vmDockerApi.startDockerHisuiJudge();
+    return data;
+  });
+  ipcMainManager.handle("RUN_DOCKER_STOP_HISUIJUDGECONTAINER", async () => {
+    const data = await vmDockerApi.stopDockerHisuiJudge();
+    return data;
+  });
+  ipcMainManager.handle("RUN_DOCKER_RESTART_HISUIJUDGECONTAINER", async () => {
+    const data = await vmDockerApi.restartDockerHisuiJudge();
+    return data;
   });
 };

--- a/src_main/main.ts
+++ b/src_main/main.ts
@@ -7,10 +7,9 @@
 
 import { app, BrowserWindow } from "electron";
 import * as path from "path";
-// import installExtension, {
-//   REACT_DEVELOPER_TOOLS,
-//   REDUX_DEVTOOLS,
-// } from "electron-devtools-installer";
+import installExtension, {
+  REACT_DEVELOPER_TOOLS,
+} from "electron-devtools-installer";
 import { setupStoreIPC, store } from "./save/save";
 import { load_ipc } from "./ipc/ipc_main";
 import {
@@ -61,6 +60,9 @@ function createWindow() {
 
   if (!app.isPackaged) {
     win.loadURL("http://localhost:3000#/mainwindow-root");
+    installExtension(REACT_DEVELOPER_TOOLS)
+      .then((name) => console.log(`Added Extension:  ${name}`))
+      .catch((err) => console.log("An error occurred: ", err));
   } else {
     // 'build/index.html'
     win.loadURL(`file://${__dirname}/../index.html#/mainwindow-root`);
@@ -113,9 +115,6 @@ function createWindow() {
     win.maximize();
   }
   // // DevTools
-  // installExtension(REACT_DEVELOPER_TOOLS)
-  //   .then((name) => console.log(`Added Extension:  ${name}`))
-  //   .catch((err) => console.log("An error occurred: ", err));
 
   // installExtension(REDUX_DEVTOOLS)
   //   .then((name) => console.log(`Added Extension:  ${name}`))

--- a/src_main/vm-system/vm-docker.test.ts
+++ b/src_main/vm-system/vm-docker.test.ts
@@ -1,0 +1,20 @@
+import { vmDockerApi } from "./vm-docker";
+jest.setTimeout(1000000);
+test("vmApi Test", async () => {
+  // expect(data.Stdout).toEqual(output);
+  const getlog = await vmDockerApi.checkDockerInstalled();
+  console.log(getlog);
+});
+
+// 並列実行によりcommand-runner-docker.test.tsと干渉する
+
+// test("docker Run Test", async () => {
+//   const startDocker = await vmDockerApi.startDockerHisuiJudge();
+//   console.log(startDocker);
+//   const getlog = await vmDockerApi.getDockerHisuiJudgeContainerStatus();
+//   console.log(getlog);
+//   const stopDockerlast = await vmDockerApi.stopDockerHisuiJudge();
+//   console.log(stopDockerlast);
+//   const getlog2 = await vmDockerApi.getDockerHisuiJudgeContainerStatus();
+//   console.log(getlog2);
+// });

--- a/src_main/vm-system/vm-docker.ts
+++ b/src_main/vm-system/vm-docker.ts
@@ -1,0 +1,141 @@
+import { execFile, spawn } from "child_process";
+import { promisify } from "util";
+import { logger } from "../tool/logger/logger";
+export interface dockerPSReturn {
+  Command: string;
+  CreatedAt: string;
+  ID: string;
+  Image: string;
+  Labels: string;
+  LocalVolumes: string;
+  Mounts: "";
+  Names: string;
+  Networks: string;
+  Ports: string;
+  RunningFor: string;
+  Size: string;
+  State: string;
+  Status: string;
+}
+export interface getDockerHisuiJudgeContainerStatusReturn {
+  status: "up" | "noContainer" | "error" | "down";
+  stderr?: string;
+  result?: dockerPSReturn;
+}
+export interface checkDockerInstalledReturn {
+  status: "success" | "error";
+  stdout: string;
+}
+class vmDocker {
+  /**
+   * Dockerのバージョンを調べて、インストール済みかを確認する
+   */
+  async checkDockerInstalled(): Promise<checkDockerInstalledReturn> {
+    return new Promise((resolve) => {
+      execFile("docker", ["--version"], (error, stdout, stderr) => {
+        if (error) {
+          resolve({ status: "error", stdout: stderr });
+        } else if (!stdout.includes("Docker version")) {
+          resolve({ status: "error", stdout: stdout });
+        }
+        resolve({ status: "success", stdout: stdout });
+      });
+    });
+  }
+  async getDockerHisuiJudgeContainerStatus(): Promise<getDockerHisuiJudgeContainerStatusReturn> {
+    return new Promise((resolve) => {
+      execFile(
+        "docker",
+        ["ps", "-a", `--format={{json .}}`],
+        (error, stdout, stderr) => {
+          if (error) {
+            resolve({ status: "error", stderr: stderr });
+          }
+          const parsedData: dockerPSReturn[] = stdout
+            .split(/\r?\n/)
+            .map((arg) => {
+              if (arg === "") {
+                return undefined;
+              } else {
+                return JSON.parse(arg);
+              }
+            })
+            .filter((a) => a !== undefined);
+          const getHisuiJudgeDockerStatus =
+            parsedData.find(
+              (a) =>
+                a.Names === "hisui-judge-docker" &&
+                a.Image.includes("adenohitu/hisui-judge-docker")
+            ) || undefined;
+          console.log(getHisuiJudgeDockerStatus);
+
+          if (getHisuiJudgeDockerStatus === undefined) {
+            resolve({ status: "noContainer" });
+          } else {
+            if (getHisuiJudgeDockerStatus.State === "running") {
+              resolve({ status: "up", result: getHisuiJudgeDockerStatus });
+            } else {
+              resolve({ status: "down", result: getHisuiJudgeDockerStatus });
+            }
+          }
+        }
+      );
+    });
+  }
+  async startDockerHisuiJudge(): Promise<"success" | "error"> {
+    return new Promise((resolve) => {
+      logger.info("docker Start event", "vmDockerApi");
+      const shellDockerRun = spawn("docker", [
+        "run",
+        "-it",
+        "-d",
+        "--name=hisui-judge-docker",
+        "adenohitu/hisui-judge-docker",
+      ]);
+      shellDockerRun.stderr.on("data", (data) => {
+        logger.error(data.toString(), "vmDockerApi");
+      });
+      shellDockerRun.stdout.on("data", (data) => {
+        logger.info(data.toString(), "vmDockerApi");
+      });
+      shellDockerRun.on("close", async (code) => {
+        if (code === 0) {
+          logger.info("docker Start:success", "vmDockerApi");
+          resolve("success");
+        } else {
+          resolve("error");
+        }
+      });
+    });
+  }
+  async stopDockerHisuiJudge(): Promise<"success" | "error"> {
+    const nowContainerStatus = await this.getDockerHisuiJudgeContainerStatus();
+    if (nowContainerStatus && nowContainerStatus.result) {
+      try {
+        await promisify(execFile)("docker", [
+          "rm",
+          "-f",
+          nowContainerStatus.result.ID,
+        ]);
+        logger.info("docker Stop:success", "vmDockerApi");
+        return "success";
+      } catch (error) {
+        logger.error("docker rm:error", "vmDockerApi");
+        return "error";
+      }
+    } else {
+      return "success";
+    }
+  }
+  async restartDockerHisuiJudge() {
+    const stopStatus = await this.stopDockerHisuiJudge();
+    if (stopStatus === "success") {
+      const startStatus = await this.startDockerHisuiJudge();
+
+      return startStatus;
+    } else {
+      return "stopError";
+    }
+  }
+}
+export const vmDockerApi = new vmDocker();


### PR DESCRIPTION
feat:Dockerマシンを起動、削除するAPIを追加

test:setTimeoutを長くした

refactor:実行中の出力をStreamで取得できるように

fix:終了コードの確認を修正

feat:vmDockerApiを操作するIPCを追加

feat:ipcSetupを共用部に移動

lint:使っていないものを削除

feat:Dockerのインストール確認機能

feat:コンテナを起動する機能を追加

refactor:移動

reafctor:handleBackを削除

feat:CommandRunnerを追加

fix:言語がうまく変わらない問題を修正

feat:Dockerを使ってジャッジをするサンプルを追加

feat:Dockerのテストを追加

fix:Dockerでコマンドが実行できるように

fix:StoreでDockerJudgeのコマンドを管理するのを修正

refactor:logger

feat:モードの変更ボタンにDockerを追加

feat:DockerComtainerの再起動ができる機能を追加